### PR TITLE
Encode private values in signed token

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const crypto = require('crypto');
 const querystring = require('querystring');
 const sshpk = require('sshpk');
 const bodyParser = require('body-parser');

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = (robot) => {
     const tokenPayload = verifyCallbackToken(req.query.token);
     if (!tokenPayload) {
       robot.log('Received invalid token');
-      res.status(401).send('Invalid token');
+      res.status(401).json({ error: 'Invalid token' });
       return;
     }
     const { appInstallationId, deployment, subdomain } = tokenPayload;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "node-fetch": "^2.1.1",
-    "probot": "^6.0.0"
+    "probot": "^6.0.0",
+    "sshpk": "^1.14.1"
   },
   "devDependencies": {
     "jest": "^21.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,6 +3460,20 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
+sshpk@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    dashdash "^1.12.0"
+    getpass "^0.1.1"
+  optionalDependencies:
+    bcrypt-pbkdf "^1.0.0"
+    ecc-jsbn "~0.1.1"
+    jsbn "~0.1.0"
+    tweetnacl "~0.14.0"
+
 sshpk@^1.7.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"


### PR DESCRIPTION
These changes make it so that the bot encodes a bunch of values in a query parameter used in the callback URL and signs that parameter with the bot's private key.

This does two things:
1) It simplifies the calls made from the deployer to the bot since the token is essentially opaque to the deployer.
2) It provides some super basic authentication. Only the bot itself can produce valid callback tokens since doing so requires the private key.